### PR TITLE
Key should be of type text

### DIFF
--- a/database/migrations/create_translations_table.php.stub
+++ b/database/migrations/create_translations_table.php.stub
@@ -18,7 +18,7 @@ class CreateTranslationsTable extends Migration
             $table->index('namespace');
             $table->string('group');
             $table->index('group');
-            $table->string('key');
+            $table->text('key');
             $table->jsonb('text');
             $table->jsonb('metadata')->nullable();
             $table->timestamps();


### PR DESCRIPTION
Translations can sometimes be really long. Because when using `__()` the value is also a key, the key must be of type text and not just string.