### PR TITLE
Fix: created date not displaying properly

### DIFF
--- a/resources/views/admin/translation/index.blade.php
+++ b/resources/views/admin/translation/index.blade.php
@@ -288,7 +288,7 @@
                                         item.text.{{ (isset(Auth::user()->language) && in_array(Auth::user()->language, config('translatable.locales'))) ? Auth::user()->language : 'en' }}
                                         }}
                                     </td>
-                                    <td>@{{ item.created_at }}</td>
+                                    <td>@{{ item.created_at | datetime }}</td>
 
                                     <td>
                                         <div class="row no-gutters">


### PR DESCRIPTION
Fixed created date not displaying properly, added date format `datetime`